### PR TITLE
Add support for various blockchains

### DIFF
--- a/Chains/arbitrum-one.json
+++ b/Chains/arbitrum-one.json
@@ -1,0 +1,14 @@
+{
+  "id": "arbitrum-one",
+  "name": "Arbitrum One",
+  "foreign_ids": {
+    "coingecko": "arbitrum",
+    "coinmarketcap": "arbitrum",
+    "binance": "arbitrum"
+  },
+  "examples": {
+    "block": "0",
+    "transaction": "0x310f2679942aa0a64d05e9f936c01cb9e3713212ef28b81dd3398285cbc0ec61",
+    "address": "0x449d9bab5855d53864969defeeaf0148f7c104f2"
+  }
+}

--- a/Chains/avalanche.json
+++ b/Chains/avalanche.json
@@ -1,0 +1,14 @@
+{
+  "id": "avalanche",
+  "name": "Avalanche",
+  "foreign_ids": {
+    "coingecko": "avalanche",
+    "coinmarketcap": "avalanche",
+    "binance": "avalanche"
+  },
+  "examples": {
+    "block": "100",
+    "transaction": "0x25550c5feac1c8a1c0ba5b6230627007fcac5969d3bb355483ca2aaf49796bf8",
+    "address": "0x27f6119df51a638be7b2b54811b80dd5b4caee9b"
+  }
+}

--- a/Chains/base.json
+++ b/Chains/base.json
@@ -1,0 +1,14 @@
+{
+  "id": "base",
+  "name": "Base",
+  "foreign_ids": {
+    "coingecko": null,
+    "coinmarketcap": null,
+    "binance": null
+  },
+  "examples": {
+    "block": "0",
+    "transaction": "0xc43b26117cdba66750690a9252fae114de3b23989874c9502a6e5084564a2f4d",
+    "address": "0x689f6b97cc8f9668af82d8c208afa67bc78e1c9a"
+  }
+}

--- a/Chains/beacon-chain.json
+++ b/Chains/beacon-chain.json
@@ -1,0 +1,14 @@
+{
+  "id": "beacon-chain",
+  "name": "Beacon Chain",
+  "foreign_ids": {
+    "coingecko": null,
+    "coinmarketcap": null,
+    "binance": null
+  },
+  "examples": {
+    "block": "100000",
+    "transaction": "3200027",
+    "address": "296190"
+  }
+}

--- a/Chains/bitcoin-cash.json
+++ b/Chains/bitcoin-cash.json
@@ -1,0 +1,14 @@
+{
+  "id": "bitcoin-cash",
+  "name": "Bitcoin Cash",
+  "foreign_ids": {
+    "coingecko": "bitcoin-cash",
+    "coinmarketcap": "bitcoin-cash",
+    "binance": "bitcoin-cash"
+  },
+  "examples": {
+    "block": "477120",
+    "transaction": "4b777745084ef83da587c7278db17f7a33ad5b831b5ee47b18c1c11c6165047c",
+    "address": "qquqx53l8ndg53hvgect6nl56zwmm37ghcu0yakvkp"
+  }
+}

--- a/Chains/bnb.json
+++ b/Chains/bnb.json
@@ -1,0 +1,14 @@
+{
+  "id": "bnb",
+  "name": "BNB",
+  "foreign_ids": {
+    "coingecko": "bnb",
+    "coinmarketcap": "bnb",
+    "binance": "bnb"
+  },
+  "examples": {
+    "block": "0",
+    "transaction": "0x283261ec450ece5e7c70c4afe39cd00860087824e4bb1d160bc55033bb2d0a67",
+    "address": "0xe2fc31f816a9b94326492132018c3aecc4a93ae1"
+  }
+}

--- a/Chains/cardano.json
+++ b/Chains/cardano.json
@@ -1,0 +1,14 @@
+{
+  "id": "cardano",
+  "name": "Cardano",
+  "foreign_ids": {
+    "coingecko": "cardano",
+    "coinmarketcap": "cardano",
+    "binance": "cardano"
+  },
+  "examples": {
+    "block": "9313781",
+    "transaction": "7468c2dd40fdb2c08e2be5ad7be76600f8d83e0f80d9626fe9ba83a96119dd5f",
+    "address": "addr1vykhj0et562lk094flx8ppdrjq7dmqffkxv99l3wyjm5c3gf2hlpm"
+  }
+}

--- a/Chains/dash.json
+++ b/Chains/dash.json
@@ -1,0 +1,14 @@
+{
+  "id": "dash",
+  "name": "Dash",
+  "foreign_ids": {
+    "coingecko": "dash",
+    "coinmarketcap": "dash",
+    "binance": "dash"
+  },
+  "examples": {
+    "block": "0",
+    "transaction": "e0028eb9648db56b1ac77cf090b99048a8007e2bb64b68f092c03c7f56a662c7",
+    "address": "XvJwrQWJYzXE5uAxHzhwyJdQSYgeg5MvGn"
+  }
+}

--- a/Chains/digibyte.json
+++ b/Chains/digibyte.json
@@ -1,0 +1,14 @@
+{
+  "id": "digibyte",
+  "name": "Digibyte",
+  "foreign_ids": {
+    "coingecko": "digibyte",
+    "coinmarketcap": "digibyte",
+    "binance": "digibyte"
+  },
+  "examples": {
+    "block": "0",
+    "transaction": "04955b63cae6a782aa43eedd4307f1145409a2771a2eed007300c48e472ac481",
+    "address": "DGbZULUsSiPitaZFN4ewsNwQEdnQ98jbCH"
+  }
+}

--- a/Chains/dogecoin.json
+++ b/Chains/dogecoin.json
@@ -1,0 +1,14 @@
+{
+  "id": "dogecoin",
+  "name": "Dogecoin",
+  "foreign_ids": {
+    "coingecko": "dogecoin",
+    "coinmarketcap": "dogecoin",
+    "binance": "dogecoin"
+  },
+  "examples": {
+    "block": "0",
+    "transaction": "5b2a3f53f605d62c53e62932dac6925e3d74afa5a4b459745c36d42d0ed26a69",
+    "address": "DQmCZQo3thCvTxkyAhPHfY7DVLqFtJ2ji6"
+  }
+}

--- a/Chains/ethereum.json
+++ b/Chains/ethereum.json
@@ -1,0 +1,14 @@
+{
+  "id": "ethereum",
+  "name": "Ethereum",
+  "foreign_ids": {
+    "coingecko": "ethereum",
+    "coinmarketcap": "ethereum",
+    "binance": "ethereum"
+  },
+  "examples": {
+    "block": "1",
+    "transaction": "0xea1093d492a1dcb1bef708f771a99a96ff05dcab81ca76c31940300177fcf49f",
+    "address": "0x2a65aca4d5fc5b5c859090a6c34d164135398226"
+  }
+}

--- a/Chains/fantom.json
+++ b/Chains/fantom.json
@@ -1,0 +1,14 @@
+{
+  "id": "fantom",
+  "name": "Fantom",
+  "foreign_ids": {
+    "coingecko": "fantom",
+    "coinmarketcap": "fantom",
+    "binance": "fantom"
+  },
+  "examples": {
+    "block": "68000000",
+    "transaction": "0x1d7ac1eb1e42cecc4ecd7586b5ce7caef7f010b8ceaaa2d2e431edb7e33f548a",
+    "address": "0x6daf1f6ee738117882b02cbd7be4041d2db54125"
+  }
+}

--- a/Chains/gnosis-chain.json
+++ b/Chains/gnosis-chain.json
@@ -1,0 +1,14 @@
+{
+  "id": "gnosis-chain",
+  "name": "Gnosis Chain",
+  "foreign_ids": {
+    "coingecko": "xdai-ecosystem",
+    "coinmarketcap": null,
+    "binance": null
+  },
+  "examples": {
+    "block": "1",
+    "transaction": "0xd2c06cec1be379be60ee59d56e93111819e226bca920009c47ee56a1c23ddd99",
+    "address": "0xa3f08080ab9ea12fc3de1fce5c9caeff63657005"
+  }
+}

--- a/Chains/handshake.json
+++ b/Chains/handshake.json
@@ -1,0 +1,14 @@
+{
+  "id": "handshake",
+  "name": "Handshake",
+  "foreign_ids": {
+    "coingecko": "handshake",
+    "coinmarketcap": "handshake",
+    "binance": "handshake"
+  },
+  "examples": {
+    "block": "0",
+    "transaction": "9553240e6f711271cfccf9407c9348996e61cb3bd39adbc2ec258ff940ff22c6",
+    "address": "hs1q7q3h4chglps004u3yn79z0cp9ed24rfr5ka9n5"
+  }
+}

--- a/Chains/litecoin.json
+++ b/Chains/litecoin.json
@@ -1,0 +1,14 @@
+{
+  "id": "litecoin",
+  "name": "Litecoin",
+  "foreign_ids": {
+    "coingecko": "litecoin",
+    "coinmarketcap": "litecoin",
+    "binance": "litecoin"
+  },
+  "examples": {
+    "block": "2257920",
+    "transaction": "1c092b270672babb297140813d6a5b7dbb8e8173273d9e360443cd5767055f98",
+    "address": "MVSbdnUxCYTXdYjE1GSK9kwF31EZauNLAf"
+  }
+}

--- a/Chains/monero.json
+++ b/Chains/monero.json
@@ -1,0 +1,14 @@
+{
+  "id": "monero",
+  "name": "Monero",
+  "foreign_ids": {
+    "coingecko": "monero",
+    "coinmarketcap": "monero",
+    "binance": "monero"
+  },
+  "examples": {
+    "block": "0",
+    "transaction": "c88ce9783b4f11190d7b9c17a69c1c52200f9faaee8e98dd07e6811175177139",
+    "address": "888tNkZrPN6JsEgekjMnABU4TBzc2Dt29EPAvkRxbANsAnjyPbb3iQ1YBRk1UXcdRsiKc9dhwMVgN5S9cQUiyoogDavup3H"
+  }
+}

--- a/Chains/opbnb.json
+++ b/Chains/opbnb.json
@@ -1,0 +1,14 @@
+{
+  "id": "opbnb",
+  "name": "opBNB",
+  "foreign_ids": {
+    "coingecko": null,
+    "coinmarketcap": null,
+    "binance": null
+  },
+  "examples": {
+    "block": "0",
+    "transaction": "0x835d817ab9d8e0854416bc8711466d8f20fb2c61e457d46e28f245b6fdc39554",
+    "address": "0xa66e2cecad16d6de42f98b8224959adc6064a442"
+  }
+}

--- a/Chains/optimism.json
+++ b/Chains/optimism.json
@@ -1,0 +1,14 @@
+{
+  "id": "optimism",
+  "name": "Optimism",
+  "foreign_ids": {
+    "coingecko": "optimism",
+    "coinmarketcap": "optimism-ethereum",
+    "binance": "optimism-ethereum"
+  },
+  "examples": {
+    "block": "100000000",
+    "transaction": "0x84e92efed88f61b6e901acb7e0d1e39ff69cf82e8fd266b06c42b02ce0a692d5",
+    "address": "0xb8ff877ed78ba520ece21b1de7843a8a57ca47cb"
+  }
+}

--- a/Chains/peercoin.json
+++ b/Chains/peercoin.json
@@ -1,0 +1,14 @@
+{
+  "id": "peercoin",
+  "name": "Peercoin",
+  "foreign_ids": {
+    "coingecko": "peercoin",
+    "coinmarketcap": "peercoin",
+    "binance": "peercoin"
+  },
+  "examples": {
+    "block": "0",
+    "transaction": "4105cc503882c6852b1ce4024c730d4d1d31342aada62c0703aa603d92f75501",
+    "address": "PTNSKANTVh6mLuCbAWTmKDZeDedddcGeZZ"
+  }
+}

--- a/Chains/polkadot.json
+++ b/Chains/polkadot.json
@@ -1,0 +1,14 @@
+{
+  "id": "polkadot",
+  "name": "Polkadot",
+  "foreign_ids": {
+    "coingecko": "polkadot",
+    "coinmarketcap": "polkadot",
+    "binance": "polkadot"
+  },
+  "examples": {
+    "block": "15822006",
+    "transaction": "0x3b9bf931486b1e4b88cdc9aef6743482aaa2358f12a458a38a9630e462adb3f8",
+    "address": "14ghKTz5mjZPgGYvgVC9VnFw1HYZmmsnYvSSHFgFTJfMvwQS"
+  }
+}

--- a/Chains/polygon-zkevm.json
+++ b/Chains/polygon-zkevm.json
@@ -1,0 +1,14 @@
+{
+  "id": "polygon-zkevm",
+  "name": "Polygon zkEVM",
+  "foreign_ids": {
+    "coingecko": null,
+    "coinmarketcap": null,
+    "binance": null
+  },
+  "examples": {
+    "block": "0",
+    "transaction": "0x00e95d9d1139543ed0cd5fcdf80f078071698e9ec7da5b1012dbfb3aca5b870a",
+    "address": "0xe25ea842727b8ac593ed106dc9cb4d1562115f10"
+  }
+}

--- a/Chains/polygon.json
+++ b/Chains/polygon.json
@@ -1,0 +1,14 @@
+{
+  "id": "polygon",
+  "name": "Polygon",
+  "foreign_ids": {
+    "coingecko": "polygon",
+    "coinmarketcap": "polygon",
+    "binance": "polygon"
+  },
+  "examples": {
+    "block": "0",
+    "transaction": "0x0c715b7ac446c896444f93b763ca8c560897a9e069e11718107ad77101f0de19",
+    "address": "0x0375b2fc7140977c9c76d45421564e354ed42277"
+  }
+}

--- a/Chains/solana.json
+++ b/Chains/solana.json
@@ -1,0 +1,14 @@
+{
+  "id": "solana",
+  "name": "Solana",
+  "foreign_ids": {
+    "coingecko": "solana",
+    "coinmarketcap": "solana",
+    "binance": "solana"
+  },
+  "examples": {
+    "block": "218705853",
+    "transaction": "4WuxY8mK4cS7WAAfgS2QPGCcEVe7aXCvA29oK23oRs4HVMkycYuCH5kTs7kXxXXDwubmBczU37WreviYSdzAiLrp",
+    "address": "8XpocjZodGQiFdoh2P33EXF1dDCJErx5nAsnz81sK4wy"
+  }
+}

--- a/Chains/ton.json
+++ b/Chains/ton.json
@@ -1,0 +1,14 @@
+{
+  "id": "ton",
+  "name": "The Open Network",
+  "foreign_ids": {
+    "coingecko": "toncoin",
+    "coinmarketcap": "toncoin",
+    "binance": "toncoin"
+  },
+  "examples": {
+    "block": "1",
+    "transaction": "3a175a1995d9634cfa527a1701daeb158b0aeb1e040a390ba697a6110ee1b9bf",
+    "address": "EQCSP1xhpNpQmIIYDwbMs2lZmy6ep496v3JfIy__DTH6ZqJ2"
+  }
+}

--- a/Chains/tron.json
+++ b/Chains/tron.json
@@ -1,0 +1,14 @@
+{
+  "id": "tron",
+  "name": "TRON",
+  "foreign_ids": {
+    "coingecko": "tron",
+    "coinmarketcap": "tron",
+    "binance": "tron"
+  },
+  "examples": {
+    "block": "52000000",
+    "transaction": "cd1d85d34914282da1556dc4222f62ed410271f934c9fe96dcfecf1e9a810b81",
+    "address": "TWjspcCqEJYLukPZYW4V5javLw7QbRj5Ye"
+  }
+}

--- a/Chains/zcash.json
+++ b/Chains/zcash.json
@@ -1,0 +1,14 @@
+{
+  "id": "zcash",
+  "name": "Zcash",
+  "foreign_ids": {
+    "coingecko": "zcash",
+    "coinmarketcap": "zcash",
+    "binance": "zcash"
+  },
+  "examples": {
+    "block": "0",
+    "transaction": "c4eaa58879081de3c24a7b117ed2b28300e7ec4c4c1dff1d3f1268b7857a4ddb",
+    "address": "t1StbPM4X3j4FGM57HpGnb9BMbS7C1nFW1r"
+  }
+}

--- a/Utils/Checker.php
+++ b/Utils/Checker.php
@@ -6,6 +6,7 @@
 $explorers = scandir('../Explorers');
 $chains = scandir('../Chains');
 $lib = [];
+$errors = [];
 
 // First, we check the validity of chain JSON files
 
@@ -25,11 +26,11 @@ for ($i = 2, $c = count($chains); $i < $c; $i++)
         if (!isset($json['name']))
             throw new Error('`name` is not set');
         if (!isset($json['foreign_ids']['coingecko']))
-            throw new Error('`foreign_ids.coingecko` is not set');
+            throw new Error('`foreign_ids.coingecko` is not set', 1);
         if (!isset($json['foreign_ids']['coinmarketcap']))
-            throw new Error('`foreign_ids.coinmarketcap` is not set');
+            throw new Error('`foreign_ids.coinmarketcap` is not set', 1);
         if (!isset($json['foreign_ids']['binance']))
-            throw new Error('`foreign_ids.binance` is not set');
+            throw new Error('`foreign_ids.binance` is not set', 1);
         if (!isset($json['examples']['block']))
             throw new Error('`examples.block` is not set');
         if (!isset($json['examples']['transaction']))
@@ -43,7 +44,13 @@ for ($i = 2, $c = count($chains); $i < $c; $i++)
     }
     catch (Throwable $t)
     {
-        echo "❌ Error: {$t->getMessage()}\n";
+        if($t->getCode() === 0) {
+            echo "❌ Error: {$t->getMessage()}\n";
+            $errors[] = $t->getMessage();
+        }
+        else {
+            echo "⚠️ Warning: {$t->getMessage()}\n";
+        }
     }
 }
 
@@ -104,6 +111,7 @@ for ($i = 2, $c = count($explorers); $i < $c; $i++)
     catch (Throwable $t)
     {
         echo "❌ Error: {$t->getMessage()}\n";
+        $errors[] = $t->getMessage();
     }
 }
 
@@ -176,4 +184,8 @@ for ($i = 2, $c = count($explorers); $i < $c; $i++)
             check_page(str_replace('%address%', $lib[$j]['examples']['address'], $chain['address']));
         }
     }
+}
+
+if(count($errors)) {
+    exit(2);
 }


### PR DESCRIPTION
- Added support for blockchains: Arbitrum One, Avalanche, Base, Beacon Chain, Bitcoin Cash, BNB, Cardano, Dash, DigiByte, Dogecoin, Ethereum, Fantom, Gnosis Chain, Handshake, Litecoin, Monero, opBNB, Optimism, Peercoin, Polkadot, Polygon, Polygon zkEVM, Solana, TON, TRON, Zcash.
- Adjust Checker: exit with code 2 when has errors, make blockchain foreign_ids.* fields optional.